### PR TITLE
Wip: conflict funcitonality must be resolved

### DIFF
--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -657,7 +657,13 @@ void DockingServer::undockRobot()
 
     // Check if the robot is docked before proceeding
     if (dock->isCharger() && (!dock->isDocked() && !dock->isCharging())) {
-      RCLCPP_INFO(get_logger(), "Robot is not in the dock, no need to undock");
+      RCLCPP_INFO(
+        get_logger(),
+        "Robot is not in the dock, no need to undock. Dock status: isDocked=%s, isCharging=%s",
+        dock->isDocked() ? "true" : "false",
+        dock->isCharging() ? "true" : "false");
+      result->success = true;
+      undocking_action_server_->succeeded_current(result);
       return;
     }
 
@@ -668,6 +674,9 @@ void DockingServer::undockRobot()
     // Get "dock pose" by finding the robot pose
     geometry_msgs::msg::PoseStamped dock_pose = getRobotPoseInFrame(params_->fixed_frame);
 
+    RCLCPP_INFO(get_logger(), "Dock pose target: %f, %f, %f", dock_pose.pose.position.x, dock_pose.pose.position.y, tf2::getYaw(dock_pose.pose.orientation));
+    RCLCPP_INFO(get_logger(), "Dock pose frame target: %s", dock_pose.header.frame_id.c_str());
+
     // Make sure that the staging pose is pointing in the same direction when moving backwards
     if (dock_backward) {
       dock_pose.pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(
@@ -677,6 +686,8 @@ void DockingServer::undockRobot()
     // Get staging pose (in fixed frame)
     geometry_msgs::msg::PoseStamped staging_pose =
       dock->getStagingPose(dock_pose.pose, dock_pose.header.frame_id);
+
+    RCLCPP_INFO(get_logger(), "Staging pose result: %f, %f, %f", staging_pose.pose.position.x, staging_pose.pose.position.y, tf2::getYaw(staging_pose.pose.orientation));
 
     // If we performed a rotation before docking backward, we must rotate the staging pose
     // to match the robot orientation


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
