### PR TITLE
add feature static layer enabled a starting

### DIFF
--- a/nav2_costmap_2d/plugins/static_layer.cpp
+++ b/nav2_costmap_2d/plugins/static_layer.cpp
@@ -118,6 +118,21 @@ StaticLayer::activate()
     std::bind(
       &StaticLayer::validateParameterUpdatesCallback,
       this, std::placeholders::_1));
+
+  // Always enable the static layer on activation to ensure map is shown.
+  if (!enabled_) {
+    RCLCPP_INFO(logger_, "Enabling static layer on activation");
+    enabled_ = true;
+
+    auto param = rclcpp::Parameter(name_ + "." + "enabled", enabled_);
+    node->set_parameter(param);
+
+    x_ = y_ = 0;
+    width_ = size_x_;
+    height_ = size_y_;
+    has_updated_data_ = true;
+    setCurrent(false);
+  }
 }
 
 void


### PR DESCRIPTION
✨ Summary of Changes

Add explicitly the reactivation of the parm callback when the node is activated again.
Ensures the parameter is activated by default

✅PR testing

- [ ]  Deactivate the static layer: ros2 param set /local_costmap/local_costmap static_layer.enabled false and in foxglove verify that the local_costmap has not the static layer.
- [ ]  Deactivate the NAV2 lifecycle node, this could be done disarming the robot
- [ ]  Reactivate the NAV2 lifecycle node, this could be done arming the robot and sending a nav2 goal
- [ ]  Check that in the local_costmap the static layer appears again while the robot is navigating.